### PR TITLE
feat:  La modification vérifie maintenant si le champ est un type 'NonNull' avant d'appeler 'parse_value'.

### DIFF
--- a/core/schema.py
+++ b/core/schema.py
@@ -183,8 +183,13 @@ class OpenIMISMutation(graphene.relay.ClientIDMutation):
     @classmethod
     def coerce_mutation_data(cls, input_data, input_class = None):
         if input_class is None:
-            input_class=cls.Input
+            input_class = cls.Input
         coerced_data = {}
+
+        if not isinstance(input_data, dict):
+            logger.debug(f"Expected input_data to be a dict but got {type(input_data)}")
+            return input_data
+
         # Iterate through the input data dictionary
         for key, value in input_data.items():
             if hasattr(input_class, key):
@@ -196,25 +201,32 @@ class OpenIMISMutation(graphene.relay.ClientIDMutation):
                     inner_type = field.of_type
                     coerced_list = []
                     for item in value:
-                        if isinstance(item, str):
-                            coerced_list.append(inner_type.parse_value(item))
+                        if isinstance(inner_type, graphene.types.enum.EnumMeta):
+                            coerced_list.append(item)  # Append the item directly for enums
+                        elif isinstance(item, str):
+                            if type(inner_type) != graphene.types.structures.NonNull:
+                                coerced_list.append(inner_type.parse_value(item))
+                            else:
+                                coerced_list.append(item) 
                         elif inner_type.__class__ == graphene.utils.subclass_with_meta.SubclassWithMeta_Meta:
                             coerced_list.append(cls.coerce_mutation_data(item, input_class = inner_type))
                         else:
                             coerced_list.append(item)
                     coerced_data[key] = coerced_list
-                elif field.__class__ == graphene.types.field.Field and isinstance(field.type, graphene.types.enum.EnumMeta):
+                elif field.__class__ == graphene.types.field.Field and isinstance(field.type,
+                                                                                  graphene.types.enum.EnumMeta):
                     # If the field type is Enum
-                    if hasattr(field.type,value):
-                        coerced_data[key] = str(getattr(field.type,value).value)
-                    else: 
+                    if hasattr(field.type, value):
+                        coerced_data[key] = str(getattr(field.type, value).value)
+                    else:
                         coerced_data[key] = value
-                elif field.__class__ == graphene.types.field.Field and isinstance(field.type,graphene.types.structures.NonNull)\
-                    and isinstance(field.type._of_type,graphene.types.enum.EnumMeta):
+                elif field.__class__ == graphene.types.field.Field and isinstance(field.type,
+                                                                                  graphene.types.structures.NonNull) \
+                        and isinstance(field.type._of_type, graphene.types.enum.EnumMeta):
                     # If the field type is Enum
-                    if hasattr(field.type,value):
-                        coerced_data[key] = str(getattr(field.type._of_type,value).value)
-                    else: 
+                    if hasattr(field.type._of_type, value):
+                        coerced_data[key] = str(getattr(field.type._of_type, value).value)
+                    else:
                         coerced_data[key] = value
                 elif field.__class__ == graphene.types.field.Field:
                     coerced_data[key] = cls.coerce_mutation_data(value, input_class = field._type)


### PR DESCRIPTION
Ajout d'un contrôle pour gérer les cas où l'objet est de type 'NonNull' et donc ne dispose pas de la méthode 'parse_value' lors de la modification des listes de prix.